### PR TITLE
More friendly welcome message

### DIFF
--- a/src/elan/config.rs
+++ b/src/elan/config.rs
@@ -335,7 +335,7 @@ impl Cfg {
 
     pub fn toolchain_for_dir(&self, path: &Path) -> Result<(Toolchain, Option<OverrideReason>)> {
         self.find_override_toolchain_or_default(path)
-            .and_then(|r| r.ok_or("no default toolchain configured".into()))
+            .and_then(|r| r.ok_or(ErrorKind::NoDefaultToolchain.into()))
     }
 
     pub fn create_command_for_dir(&self, path: &Path, binary: &str) -> Result<Command> {

--- a/src/elan/errors.rs
+++ b/src/elan/errors.rs
@@ -22,6 +22,9 @@ error_chain! {
             description("toolchain is not installed")
             display("toolchain '{}' is not installed", t)
         }
+        NoDefaultToolchain {
+            description("no default toolchain configured. run `elan toolchain install nightly`")
+        }
         OverrideToolchainNotInstalled(t: String) {
             description("override toolchain is not installed")
             display("override toolchain '{}' is not installed", t)


### PR DESCRIPTION
When installed as a system package, the `lean` proxy shows an unhelpful error message when run the first time:
```
± lean
error: no default toolchain configured
```

This PR augments the error message by suggesting to run `elan toolchain install nightly`, which seems like the most reasonable choice at the moment.