### PR TITLE
Add colon-delimited custom toolchain origins

### DIFF
--- a/src/elan-dist/src/manifestation.rs
+++ b/src/elan-dist/src/manifestation.rs
@@ -28,6 +28,7 @@ impl Manifestation {
 
     /// Installation using the legacy v1 manifest format
     pub fn update(&self,
+                  origin: &String,
                   url: &String,
                   temp_cfg: &temp::Cfg,
                   notify_handler: &Fn(Notification)) -> Result<()> {
@@ -54,7 +55,7 @@ impl Manifestation {
         } else {
             unreachable!()
         };
-        let re = Regex::new(r#"/leanprover/[a-z-]+/releases/download/[^"]+"#).unwrap();
+        let re = Regex::new(format!(r#"/{}/releases/download/[^"]+"#, origin).as_str()).unwrap();
         let download_page_file = dlcfg.download_and_check(&url, "")?;
         let mut html = String::new();
         fs::File::open(&download_page_file as &::std::path::Path)?.read_to_string(&mut html)?;


### PR DESCRIPTION
This pull request strictly adds functionality to lean version selection. It permits a GitHub repository "user/repo" combination, followed by a colon, to prefix the version string which can be specified as the `lean_version`.

For example, if `lean_version = "khoek/klean:3.4.1"` (naming my random lean fork) was to appear in the `leanpkg.toml` of a project, then elan will now instead fetch the release from the right page under https://github.com/khoek/klean, expecting that the release is packaged and named exactly as is currently the format in the `leanprover/lean` mainline. The shorthand tracking labels `lean_version = "khoek/klean:stable"` and `lean_version = "khoek/klean:nightly"` are also kept available, with the assumption that when `nightly` is specified we should append "-nightly" to the repository name.

To all currently (legally) declared `lean_version`s there is no functional change, and the semantics we add strictly make legal previously illegal `lean_version`s.

In addition to the obvious required changes to `elan-dist/src/dist.rs` to look up different URLs, notably `elan/toolchain.rs` had to be modified in order that the colon and forward-slash characters not be emitted when generating pathnames for installing and looking-up the custom toolchains.